### PR TITLE
[FIX] only show matching results in search, search for multiple strin…

### DIFF
--- a/Classes/Xclass/FileRepositoryXclass.php
+++ b/Classes/Xclass/FileRepositoryXclass.php
@@ -42,27 +42,29 @@ class FileRepositoryXclass extends FileRepository
 
         $fileUidsFromMetaDataRecordsMatchingSearchWord = $this->getFileUidsFromSysFileMetaDataRecordsMatchingSearchWord($searchWord);
 
-        $files = array();
+        $files = [];
         foreach ($fileRecords as $fileRecord) {
-            if (!empty($allowedFileExtension)
-                && !in_array($fileRecord['extension'], $allowedFileExtension)
-            ) {
-                continue;
-            }
-            if (!empty($fileUidsFromMetaDataRecordsMatchingSearchWord)
-                && !in_array($fileRecord['uid'],
-                    $fileUidsFromMetaDataRecordsMatchingSearchWord) && stristr($fileRecord['name'],
-                    $searchWord) === false
-            ) {
-                continue;
-            }
             try {
-                $files[] = $fileFactory->getFileObject($fileRecord['uid'], $fileRecord);
+                if (!empty($allowedFileExtension)
+                    && !in_array($fileRecord['extension'], $allowedFileExtension)
+                ) {
+                    continue;
+                }
+                if (!empty($fileUidsFromMetaDataRecordsMatchingSearchWord)
+                    && in_array($fileRecord['uid'], $fileUidsFromMetaDataRecordsMatchingSearchWord)
+                ) {
+                    $files[] = $fileFactory->getFileObject($fileRecord['uid'], $fileRecord);
+                }
+                $nameParts = str_getcsv($searchWord, ' ');
+                foreach ($nameParts as $namePart) {
+                    if (strpos($fileRecord['name'], $namePart) !== false) {
+                        $files[] = $fileFactory->getFileObject($fileRecord['uid'], $fileRecord);
+                    }
+                }
             } catch (\TYPO3\CMS\Core\Resource\Exception\FileDoesNotExistException $ignoredException) {
                 continue;
             }
         }
-
         return $files;
     }
 


### PR DESCRIPTION
Hi Jörg,
in your current version of the method searchByname we get all files of a folder and the subfolders if $allowedFileExtension and $fileUidsFromMetaDataRecordsMatchingSearchWord are empty. I think this is not we want to achieve with a search.
Also it was not possible to search for multiple words in a filename. I added this functionality.
Please have a look at my code. I would like to hear your feedback ;)