### PR TITLE
[BUGFIX] Prevent "Nesting level too deep" error in search

### DIFF
--- a/Classes/Xclass/FileRepositoryXclass.php
+++ b/Classes/Xclass/FileRepositoryXclass.php
@@ -74,7 +74,7 @@ class FileRepositoryXclass extends FileRepository
                     foreach ($nameParts as $namePart) {
                         $fileObject = $fileFactory->getFileObject($file->getUid(), $file->getProperties());
                         // Find matches AND prevent prevent duplicate results
-                        if (stripos($file->getName(), $namePart) !== false && !in_array($fileObject, $filesMatchingSearchWord)) {
+                        if (stripos($file->getName(), $namePart) !== false && !in_array($fileObject, $filesMatchingSearchWord, true)) {
                             $filesMatchingSearchWord[] = $fileObject;
                         }
                     }


### PR DESCRIPTION
To prevent duplicates in the search result, there is a check via
`in_array` in place. The default behavior of `in_array` is a comparison
of all properties of the objects. This can result in a PHP Fatal error
"Nesting level too deep".

The error can be prevented by using a strict comparison, which can be
achieved by passing `true` as third parameter.